### PR TITLE
Add missing parameter in CreateUsageCharge command description

### DIFF
--- a/src/ServiceDescription/Shopify-v1.php
+++ b/src/ServiceDescription/Shopify-v1.php
@@ -2581,6 +2581,12 @@ return [
                     'location'    => 'json',
                     'type'        => 'number',
                     'required'    => true
+                ],
+                'recurring_charge_id' => [
+                    'description' => 'Recurring charge from which we need to extract usage charges',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
                 ]
             ]
         ],


### PR DESCRIPTION
To satisfy the shopify API createUsageCharges call we need to pass in uri the recurring_application_charge_id